### PR TITLE
Don't cancel alarm if last_rtc_alarm_id hasn't been set

### DIFF
--- a/src/boards/rp2040/rtc-board.c
+++ b/src/boards/rp2040/rtc-board.c
@@ -72,14 +72,18 @@ static int64_t alarm_callback(alarm_id_t id, void *user_data) {
 
 void RtcSetAlarm( uint32_t timeout )
 {
-    alarm_pool_cancel_alarm(rtc_alarm_pool, last_rtc_alarm_id);
+    if (last_rtc_alarm_id > -1) {
+        alarm_pool_cancel_alarm(rtc_alarm_pool, last_rtc_alarm_id);
+    }
 
     last_rtc_alarm_id = alarm_pool_add_alarm_at(rtc_alarm_pool, delayed_by_us(rtc_timer_context, timeout), alarm_callback, NULL, true);
 }
 
 void RtcStopAlarm( void )
 {
-    alarm_pool_cancel_alarm(rtc_alarm_pool, last_rtc_alarm_id);
+    if (last_rtc_alarm_id > -1) {
+        alarm_pool_cancel_alarm(rtc_alarm_pool, last_rtc_alarm_id);
+    }
 }
 
 uint32_t RtcMs2Tick( TimerTime_t milliseconds )


### PR DESCRIPTION
Hi, thanks for this! I was trying to get this working with a Pi Pico and a [RFM95W](https://www.digikey.com/en/products/detail/rf-solutions/RFM95W-915S2/6564923), and for some reason I was getting an assertion error in the pico-sdk:

https://github.com/raspberrypi/pico-sdk/blob/master/src/common/pico_util/include/pico/util/pheap.h#L105

Changing the `alarm_pool_create` `max_timers` attribute in this PR seemed to fix the error, but I'm not sure why.. Do you have any ideas why this would be happening? Perhaps I'm using an incompatible version of the SDK?

Please don't hesitate to close this PR if it isn't appropriate. Thanks!