### PR TITLE
Update LoRaMAC Node submodule from version 4.5.1 to 4.6.0

### DIFF
--- a/src/boards/rp2040/eeprom-board.c
+++ b/src/boards/rp2040/eeprom-board.c
@@ -24,18 +24,18 @@ void EepromMcuInit()
     memcpy(eeprom_write_cache, EEPROM_ADDRESS, sizeof(eeprom_write_cache));
 }
 
-uint8_t EepromMcuReadBuffer( uint16_t addr, uint8_t *buffer, uint16_t size )
+LmnStatus_t EepromMcuReadBuffer( uint16_t addr, uint8_t *buffer, uint16_t size )
 {
     memcpy(buffer, eeprom_write_cache + addr, size);
     
-    return SUCCESS;
+    return LMN_STATUS_OK;
 }
 
-uint8_t EepromMcuWriteBuffer( uint16_t addr, uint8_t *buffer, uint16_t size )
+LmnStatus_t EepromMcuWriteBuffer( uint16_t addr, uint8_t *buffer, uint16_t size )
 {
     memcpy(eeprom_write_cache + addr, buffer, size);
 
-    return SUCCESS;
+    return LMN_STATUS_OK;
 }
 
 uint8_t EepromMcuFlush()


### PR DESCRIPTION
Because why not? ;-) 

Use an updated version with possible version fixes.
eeprom-board.c has been adapted to reflect the changed function return
types.