### PR TITLE
new function lorawan_nvm_in_use()

### DIFF
--- a/src/boards/rp2040/eeprom-board.c
+++ b/src/boards/rp2040/eeprom-board.c
@@ -18,22 +18,38 @@
 #define EEPROM_ADDRESS ((const uint8_t*)(XIP_BASE + EEPROM_OFFSET))
 
 static uint8_t eeprom_write_cache[EEPROM_SIZE];
+static uint8_t eeprom_in_use = 0; // used to track if the EEPROM is being accessed or not
+
+uint8_t EepromInUse()
+{
+    if (eeprom_in_use) {
+        return (1);
+    } else {
+        return (0);
+    }
+}
 
 void EepromMcuInit()
 {
+    eeprom_in_use = 1;
     memcpy(eeprom_write_cache, EEPROM_ADDRESS, sizeof(eeprom_write_cache));
+    eeprom_in_use = 0;
 }
 
 uint8_t EepromMcuReadBuffer( uint16_t addr, uint8_t *buffer, uint16_t size )
 {
+    eeprom_in_use = 1;
     memcpy(buffer, eeprom_write_cache + addr, size);
+    eeprom_in_use = 0;
     
     return SUCCESS;
 }
 
 uint8_t EepromMcuWriteBuffer( uint16_t addr, uint8_t *buffer, uint16_t size )
 {
+    eeprom_in_use = 1;
     memcpy(eeprom_write_cache + addr, buffer, size);
+    eeprom_in_use = 0;
 
     return SUCCESS;
 }
@@ -42,10 +58,12 @@ uint8_t EepromMcuFlush()
 {
     uint32_t mask;
 
+    eeprom_in_use = 1;
     BoardCriticalSectionBegin(&mask);
 
     flash_range_erase(EEPROM_OFFSET, sizeof(eeprom_write_cache));
     flash_range_program(EEPROM_OFFSET, eeprom_write_cache, sizeof(eeprom_write_cache));
 
     BoardCriticalSectionEnd(&mask);
+    eeprom_in_use = 0;
 }

--- a/src/include/pico/lorawan.h
+++ b/src/include/pico/lorawan.h
@@ -68,6 +68,8 @@ void lorawan_debug(bool debug);
 
 int lorawan_erase_nvm();
 
+int lorawan_nvm_in_use();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lorawan.c
+++ b/src/lorawan.c
@@ -182,6 +182,7 @@ static bool Debug = false;
 
 extern void EepromMcuInit();
 extern uint8_t EepromMcuFlush();
+extern uint8_t EepromInUse();
 
 const char* lorawan_default_dev_eui(char* dev_eui)
 {
@@ -359,6 +360,15 @@ int lorawan_erase_nvm()
     EepromMcuFlush();
 
     return 0;
+}
+
+int lorawan_nvm_in_use()
+{
+    if (EepromInUse()) {
+        return(1);
+    } else {
+        return(0);
+    }
 }
 
 static void OnMacProcessNotify( void )


### PR DESCRIPTION
The new function is used to determine if the NVM is in use or not, in case the microcontroller wishes to power itself off