### PR TITLE
Changes to improve useability with class C devices

### DIFF
--- a/src/boards/rp2040/sx1276-board.c
+++ b/src/boards/rp2040/sx1276-board.c
@@ -67,11 +67,26 @@ const struct Radio_s Radio =
 
 static DioIrqHandler** irq_handlers;
 
-void dio_gpio_callback(uint gpio, uint32_t events)
+// void dio_gpio_callback(uint gpio, uint32_t events)
+// {
+//     if (gpio == SX1276.DIO0.pin) {
+//         irq_handlers[0](NULL);
+//     } else if (gpio == SX1276.DIO1.pin) {
+//         irq_handlers[1](NULL);
+//     }
+// }
+
+
+void dio_gpio_callback()
 {
-    if (gpio == SX1276.DIO0.pin) {
+    if(gpio_get_irq_event_mask(SX1276.DIO0.pin) & GPIO_IRQ_EDGE_RISE)
+    {
+        gpio_acknowledge_irq(SX1276.DIO0.pin, GPIO_IRQ_EDGE_RISE);
         irq_handlers[0](NULL);
-    } else if (gpio == SX1276.DIO1.pin) {
+    }
+    if(gpio_get_irq_event_mask(SX1276.DIO1.pin) & GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL)
+    {
+        gpio_acknowledge_irq(SX1276.DIO1.pin, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL);
         irq_handlers[1](NULL);
     }
 }
@@ -122,8 +137,19 @@ void SX1276IoIrqInit( DioIrqHandler **irqHandlers )
 {
     irq_handlers = irqHandlers;
 
-    gpio_set_irq_enabled_with_callback(SX1276.DIO0.pin, GPIO_IRQ_EDGE_RISE, true, &dio_gpio_callback);
-    gpio_set_irq_enabled_with_callback(SX1276.DIO1.pin, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true, &dio_gpio_callback);
+    gpio_set_irq_enabled(SX1276.DIO0.pin, GPIO_IRQ_EDGE_RISE, true);  
+    gpio_add_raw_irq_handler(SX1276.DIO0.pin,&dio_gpio_callback);
+
+    irq_set_enabled(IO_IRQ_BANK0,true);
+
+
+    gpio_set_irq_enabled(SX1276.DIO1.pin, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true);  
+    gpio_add_raw_irq_handler(SX1276.DIO1.pin,&dio_gpio_callback);
+
+    irq_set_enabled(IO_IRQ_BANK0,true);
+
+    // gpio_set_irq_enabled_with_callback(SX1276.DIO0.pin, GPIO_IRQ_EDGE_RISE, true, &dio_gpio_callback);
+    // gpio_set_irq_enabled_with_callback(SX1276.DIO1.pin, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true, &dio_gpio_callback);
 }
 
 /*!

--- a/src/boards/rp2040/sx1276-board.c
+++ b/src/boards/rp2040/sx1276-board.c
@@ -137,14 +137,13 @@ void SX1276IoIrqInit( DioIrqHandler **irqHandlers )
 {
     irq_handlers = irqHandlers;
 
-    gpio_set_irq_enabled(SX1276.DIO0.pin, GPIO_IRQ_EDGE_RISE, true);  
     gpio_add_raw_irq_handler(SX1276.DIO0.pin,&dio_gpio_callback);
+    gpio_set_irq_enabled(SX1276.DIO0.pin, GPIO_IRQ_EDGE_RISE, true);  
 
     irq_set_enabled(IO_IRQ_BANK0,true);
 
-
-    gpio_set_irq_enabled(SX1276.DIO1.pin, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true);  
     gpio_add_raw_irq_handler(SX1276.DIO1.pin,&dio_gpio_callback);
+    gpio_set_irq_enabled(SX1276.DIO1.pin, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true);  
 
     irq_set_enabled(IO_IRQ_BANK0,true);
 

--- a/src/include/pico/lorawan.h
+++ b/src/include/pico/lorawan.h
@@ -44,6 +44,8 @@ struct lorawan_otaa_settings {
     const char* channel_mask;
 };
 
+int lorawan_change_device_class(DeviceClass_t newClass);
+
 const char* lorawan_default_dev_eui(char* dev_eui);
 
 int lorawan_init(const struct lorawan_sx1276_settings* sx1276_settings, LoRaMacRegion_t region);

--- a/src/lorawan.c
+++ b/src/lorawan.c
@@ -52,14 +52,14 @@
  *
  * \remark Please note that when ADR is enabled the end-device should be static
  */
-#define LORAWAN_ADR_STATE                           LORAMAC_HANDLER_ADR_OFF
+#define LORAWAN_ADR_STATE                           LORAMAC_HANDLER_ADR_ON
 
 /*!
  * Default datarate
  *
  * \remark Please note that LORAWAN_DEFAULT_DATARATE is used only when ADR is disabled 
  */
-#define LORAWAN_DEFAULT_DATARATE                    DR_1
+#define LORAWAN_DEFAULT_DATARATE                    DR_0
 
 /*!
  * LoRaWAN confirmed messages
@@ -76,7 +76,7 @@
  *
  * \remark Please note that ETSI mandates duty cycled transmissions. Use only for test purposes
  */
-#define LORAWAN_DUTYCYCLE_ON                        false
+#define LORAWAN_DUTYCYCLE_ON                        true
 
 /*!
  * Indicates if the end-device is to be connected to a private or public network

--- a/src/lorawan.c
+++ b/src/lorawan.c
@@ -52,14 +52,14 @@
  *
  * \remark Please note that when ADR is enabled the end-device should be static
  */
-#define LORAWAN_ADR_STATE                           LORAMAC_HANDLER_ADR_ON
+#define LORAWAN_ADR_STATE                           LORAMAC_HANDLER_ADR_OFF
 
 /*!
  * Default datarate
  *
  * \remark Please note that LORAWAN_DEFAULT_DATARATE is used only when ADR is disabled 
  */
-#define LORAWAN_DEFAULT_DATARATE                    DR_0
+#define LORAWAN_DEFAULT_DATARATE                    DR_1
 
 /*!
  * LoRaWAN confirmed messages
@@ -76,7 +76,7 @@
  *
  * \remark Please note that ETSI mandates duty cycled transmissions. Use only for test purposes
  */
-#define LORAWAN_DUTYCYCLE_ON                        true
+#define LORAWAN_DUTYCYCLE_ON                        false
 
 /*!
  * Indicates if the end-device is to be connected to a private or public network
@@ -183,6 +183,15 @@ static bool Debug = false;
 
 extern void EepromMcuInit();
 extern uint8_t EepromMcuFlush();
+
+
+static DeviceClass_t deviceClass = LORAWAN_DEFAULT_CLASS;
+
+int lorawan_change_device_class(DeviceClass_t newClass)
+{
+    deviceClass = newClass;
+    return LmHandlerRequestClass( deviceClass );
+}
 
 const char* lorawan_default_dev_eui(char* dev_eui)
 {
@@ -582,7 +591,7 @@ static void OnJoinRequest( LmHandlerJoinParams_t* params )
     }
     else
     {
-        LmHandlerRequestClass( LORAWAN_DEFAULT_CLASS );
+        LmHandlerRequestClass( deviceClass );
     }
 }
 


### PR DESCRIPTION
Made a couple changes to make it easier to use class C devices and gpio interrupts. 

- added a function called int lorawan_change_device_class(DeviceClass_t newClass) that changes a global variable deivceClass to newClass and runs the LmHandlerRequestClass function.
- Changed the IRQ call for dio_gpio_callback to be a raw IRQ handler in order to free up the default GPIO IRQ callback mechanism for the user application.