### PR TITLE
User TX/RX callbacks

### DIFF
--- a/src/include/pico/lorawan.h
+++ b/src/include/pico/lorawan.h
@@ -16,6 +16,7 @@ extern "C" {
 #include "hardware/spi.h"
 
 #include "LoRaMac.h"
+#include "LmHandler.h"
 
 struct lorawan_sx1276_settings {
     struct {
@@ -61,6 +62,10 @@ int lorawan_process();
 int lorawan_process_timeout_ms(uint32_t timeout_ms);
 
 int lorawan_send_unconfirmed(const void* data, uint8_t data_len, uint8_t app_port);
+
+void lorawan_set_tx_callback(void (*callback)(LmHandlerTxParams_t* params));
+
+void lorawan_set_rx_callback(void (*callback)(LmHandlerRxParams_t* params));
 
 int lorawan_receive(void* data, uint8_t data_len, uint8_t* app_port);
 

--- a/src/lorawan.c
+++ b/src/lorawan.c
@@ -586,11 +586,23 @@ static void OnJoinRequest( LmHandlerJoinParams_t* params )
     }
 }
 
+void (*tx_callback)(LmHandlerTxParams_t* params) = NULL;
+void (*rx_callback)(LmHandlerRxParams_t* params) = NULL;
+
 static void OnTxData( LmHandlerTxParams_t* params )
 {
     if (Debug) {
         DisplayTxUpdate( params );
     }
+
+    if (tx_callback != NULL) {
+        tx_callback( params );
+    }
+}
+
+void lorawan_set_tx_callback( void (*callback)(LmHandlerTxParams_t*) )
+{
+    tx_callback = callback;
 }
 
 static void OnRxData( LmHandlerAppData_t* appData, LmHandlerRxParams_t* params )
@@ -602,6 +614,15 @@ static void OnRxData( LmHandlerAppData_t* appData, LmHandlerRxParams_t* params )
     memcpy(AppRxData.Buffer, appData->Buffer, appData->BufferSize);
     AppRxData.BufferSize = appData->BufferSize;
     AppRxData.Port = appData->Port;
+
+    if (rx_callback != NULL) {
+        rx_callback( params );
+    }
+}
+
+void lorawan_set_rx_callback( void (*callback)(LmHandlerRxParams_t*) )
+{
+    rx_callback = callback;
 }
 
 static void OnClassChange( DeviceClass_t deviceClass )

--- a/src/lorawan.c
+++ b/src/lorawan.c
@@ -586,8 +586,8 @@ static void OnJoinRequest( LmHandlerJoinParams_t* params )
     }
 }
 
-void (*tx_callback)(LmHandlerTxParams_t* params) = NULL;
-void (*rx_callback)(LmHandlerRxParams_t* params) = NULL;
+void (*txCallback)(LmHandlerTxParams_t* params) = NULL;
+void (*rxCallback)(LmHandlerRxParams_t* params) = NULL;
 
 static void OnTxData( LmHandlerTxParams_t* params )
 {
@@ -595,14 +595,14 @@ static void OnTxData( LmHandlerTxParams_t* params )
         DisplayTxUpdate( params );
     }
 
-    if (tx_callback != NULL) {
-        tx_callback( params );
+    if (txCallback != NULL) {
+        txCallback( params );
     }
 }
 
 void lorawan_set_tx_callback( void (*callback)(LmHandlerTxParams_t*) )
 {
-    tx_callback = callback;
+    txCallback = callback;
 }
 
 static void OnRxData( LmHandlerAppData_t* appData, LmHandlerRxParams_t* params )
@@ -615,14 +615,14 @@ static void OnRxData( LmHandlerAppData_t* appData, LmHandlerRxParams_t* params )
     AppRxData.BufferSize = appData->BufferSize;
     AppRxData.Port = appData->Port;
 
-    if (rx_callback != NULL) {
-        rx_callback( params );
+    if (rxCallback != NULL) {
+        rxCallback( params );
     }
 }
 
 void lorawan_set_rx_callback( void (*callback)(LmHandlerRxParams_t*) )
 {
-    rx_callback = callback;
+    rxCallback = callback;
 }
 
 static void OnClassChange( DeviceClass_t deviceClass )


### PR DESCRIPTION
For my project, I wanted to be able to have direct access to the TX/RX callbacks from LoRaMAC (I was trying to send confirmed messages, and wanted to receive the ACK). It would be nice to provide some functions for users to register their own callbacks if desired

(Maybe eventually allowing users to selectively override library callbacks to LoRaMAC and provide custom implementations for advanced users, although that might be a bit much :)